### PR TITLE
chore: Update workflow to support PR, push, and manual triggers

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,5 +1,5 @@
-# Your GitHub workflow file under .github/workflows/
-# Trigger the action on push to main
+name: CI + Deploy
+
 on:
   push:
     branches:
@@ -9,23 +9,16 @@ on:
       - main
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   actions: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
-  publish-docs:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  # -----------------------------
+  # Build / Test job (run on PR, main push, or manual)
+  # -----------------------------
+  build-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,14 +33,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MY_PAT }}
         run: git submodule update --init --recursive
-      
-      - run: dotnet tool update -g docfx
-      - run: docfx doc/docfx.json
+
+      - name: Install DocFX
+        run: dotnet tool update -g docfx
+
+      - name: Build Docs
+        run: docfx doc/docfx.json
+
+  # -----------------------------
+  # Deploy job (only run on push to main)
+  # -----------------------------
+  deploy-pages:
+    needs: build-docs
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
           path: 'doc/_site'
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Dotnet Setup
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
 
       - name: Update submodules
         env:


### PR DESCRIPTION
### 💡 Feature Description
Update the GitHub Actions workflow to:
1. Automatically run on pull requests to main (pre-merge validation)
2. Run on push to main (post-merge)
3. Support manual triggering via workflow_dispatch

This ensures the workflow can be tested safely before merging and can also be manually triggered if needed.

---

### ⚖ Alternatives Considered
N/A

---

### 📝 Additional Information
None
